### PR TITLE
New TC/TA wrappers to access TA/TC inputs in python

### DIFF
--- a/pybindsrc/trigger_activity.cpp
+++ b/pybindsrc/trigger_activity.cpp
@@ -28,7 +28,6 @@ struct TriggerActivityHolder {
     m_size = size;
     m_data.reset(new uint8_t[m_size]);
     std::memcpy(m_data.get(), ptr, size);
-    std::cout << "Buffer size " << size << " vs TAData size " << sizeof(trgdataformats::TriggerActivityData) << std::endl;
   }
 
   TriggerActivity* ptr() { return reinterpret_cast<TriggerActivity*>(m_data.get());  }

--- a/pybindsrc/trigger_candidate.cpp
+++ b/pybindsrc/trigger_candidate.cpp
@@ -115,7 +115,7 @@ register_trigger_candidate(py::module& m)
           }, py::return_value_policy::reference_internal
       )
       .def_property_readonly("data", [](TriggerCandidateHolder& self) -> TriggerCandidateData& {return self.ptr()->data;})
-      .def("n_inputs", [](TriggerActivityHolder& self){ return self.ptr()->n_inputs; })
+      .def("n_inputs", [](TriggerCandidateHolder& self){ return self.ptr()->n_inputs; })
       .def("__len__", [](TriggerCandidateHolder& self){ return self.ptr()->n_inputs; })
       .def("__getitem__",
             [](TriggerCandidateHolder &self, size_t i) -> const TriggerActivityData& {

--- a/pybindsrc/trigger_candidate.cpp
+++ b/pybindsrc/trigger_candidate.cpp
@@ -21,10 +21,10 @@ namespace python {
 /*
  Doesn't work
 */
-struct TriggerCandidateWrapper {
+struct TriggerCandidateHolder {
 
 
-  TriggerCandidateWrapper(void* ptr, size_t size) {
+  TriggerCandidateHolder(void* ptr, size_t size) {
     m_size = size;
     m_data.reset(new uint8_t[m_size]);
     std::memcpy(m_data.get(), ptr, size);
@@ -88,7 +88,7 @@ register_trigger_candidate(py::module& m)
     ;
 
 
-  py::class_<TriggerCandidate>(m, "TriggerCandidate", py::buffer_protocol())
+  py::class_<TriggerCandidate>(m, "TriggerCandidateOverlay", py::buffer_protocol())
       .def(py::init())
       .def(py::init([](py::capsule capsule) {
         auto tp = *static_cast<TriggerCandidate*>(capsule.get_pointer());
@@ -100,32 +100,31 @@ register_trigger_candidate(py::module& m)
     ;
 
 
-    py::class_<TriggerCandidateWrapper>(m, "TriggerCandidateWrapper", py::buffer_protocol())
+    py::class_<TriggerCandidateHolder>(m, "TriggerCandidate", py::buffer_protocol())
       .def(py::init([](py::bytes bytes){
           py::buffer_info info(py::buffer(bytes).request());
 
-          TriggerCandidateWrapper taw(info.ptr, info.itemsize);
+          TriggerCandidateHolder tch(info.ptr, info.size);
 
-          return taw;
+          return tch;
         }))
 
       .def("get_bytes",
-          [](TriggerCandidateWrapper& taw) -> py::bytes {
-            return py::bytes(reinterpret_cast<char*>(taw.ptr()), taw.m_size);
+          [](TriggerCandidateHolder& tch) -> py::bytes {
+            return py::bytes(reinterpret_cast<char*>(tch.ptr()), tch.m_size);
           }, py::return_value_policy::reference_internal
       )
-      .def_property_readonly("data", [](TriggerCandidateWrapper& self) -> TriggerCandidateData& {return self.ptr()->data;})
-      .def("__len__", [](TriggerCandidateWrapper& self){ return self.ptr()->n_inputs; })
+      .def_property_readonly("data", [](TriggerCandidateHolder& self) -> TriggerCandidateData& {return self.ptr()->data;})
+      .def("n_inputs", [](TriggerActivityHolder& self){ return self.ptr()->n_inputs; })
+      .def("__len__", [](TriggerCandidateHolder& self){ return self.ptr()->n_inputs; })
       .def("__getitem__",
-            [](TriggerCandidateWrapper &self, size_t i) -> const TriggerActivityData& {
+            [](TriggerCandidateHolder &self, size_t i) -> const TriggerActivityData& {
                 if (i >= self.ptr()->n_inputs) {
                     throw py::index_error();
                 }
                 return self.ptr()->inputs[i];
             }, py::return_value_policy::reference_internal)
-      .def("sizeof", [](TriggerCandidateWrapper& self){ return self.m_size; })
-      // .def("sizeof", [](TriggerCandidateWrapper& self){ return sizeof(TriggerCandidate)+self.ptr->n_inputs*sizeof(TriggerPrimitive); })
-      
+      .def("sizeof", [](TriggerCandidateHolder& self){ return self.m_size; })
       ;
 }
 


### PR DESCRIPTION
The implementation of TA and TC overlay classes, using empty c-style arrays to access the list of input objects, poses a problem in terms of python bindings: the `n_input` array is not copied when building the TA/TC python object.
This can be solved by introducing an intermediate class (python only) that owns the full block of memory representing the TA/TC.
This PR introduces `TriggerActivityHolder` and `TriggerCandidateHolder` classes (pybind only) that implement this pattern.
