### PR TITLE
New ChannelDistance Algorithm

### DIFF
--- a/include/trgdataformats/TriggerActivityData.hpp
+++ b/include/trgdataformats/TriggerActivityData.hpp
@@ -33,6 +33,7 @@ struct TriggerActivityData
     kMichelElectron = 5,
     kDBSCAN = 6,
     kPlaneCoincidence = 7,
+    kChannelDistance = 8,
   };
 
   // Update this version number if there are any changes to the in-memory representation of this class!

--- a/include/trgdataformats/TriggerCandidateData.hpp
+++ b/include/trgdataformats/TriggerCandidateData.hpp
@@ -79,6 +79,7 @@ get_trigger_candidate_type_names()
     { TriggerCandidateData::Type::kHorizontalMuon, "kHorizontalMuon" },
     { TriggerCandidateData::Type::kMichelElectron, "kMichelElectron" },
     { TriggerCandidateData::Type::kPlaneCoincidence, "kPlaneCoincidence" },
+    { TriggerCandidateData::Type::kChannelDistance, "kChannelDistance" },
   };
 }
 

--- a/include/trgdataformats/TriggerCandidateData.hpp
+++ b/include/trgdataformats/TriggerCandidateData.hpp
@@ -31,6 +31,7 @@ struct TriggerCandidateData
     kHorizontalMuon = 7,
     kMichelElectron = 8,
     kPlaneCoincidence = 9,
+    kChannelDistance = 10,
   };
 
   enum class Algorithm
@@ -44,6 +45,7 @@ struct TriggerCandidateData
     kMichelElectron = 6, 
     kPlaneCoincidence = 7,    
     kCustom = 8, 
+    kChannelDistance = 9,
   };
 
   // Update this version number if there are any changes to the in-memory representation of this class!

--- a/pybindsrc/trigger_activity.cpp
+++ b/pybindsrc/trigger_activity.cpp
@@ -56,6 +56,7 @@ register_trigger_activity(py::module& m)
     .value("kHorizontalMuon", TriggerActivityData::Algorithm::kHorizontalMuon)
     .value("kMichelElectron", TriggerActivityData::Algorithm::kMichelElectron)
     .value("kDBSCAN", TriggerActivityData::Algorithm::kDBSCAN)
+    .value("kChannelDistance", TriggerActivityData::Algorithm::kChannelDistance)
     .export_values();
 
   py::class_<TriggerActivityData>(m, "TriggerActivityData", py::buffer_protocol())

--- a/pybindsrc/trigger_candidate.cpp
+++ b/pybindsrc/trigger_candidate.cpp
@@ -53,6 +53,7 @@ register_trigger_candidate(py::module& m)
     .value("kHorizontalMuon", TriggerCandidateData::Type::kHorizontalMuon)
     .value("kMichelElectron", TriggerCandidateData::Type::kMichelElectron)
     .value("kPlaneCoincidence", TriggerCandidateData::Type::kPlaneCoincidence)
+    .value("kChannelDistance", TriggerCandidateData::Type::kChannelDistance)
     .export_values();
 
   py::enum_<TriggerCandidateData::Algorithm>(m, "TriggerCandidateData::Algorithm")
@@ -64,6 +65,7 @@ register_trigger_candidate(py::module& m)
     .value("kHorizontalMuon", TriggerCandidateData::Algorithm::kHorizontalMuon)
     .value("kPlaneCoincidence", TriggerCandidateData::Algorithm::kPlaneCoincidence)
     .value("kCustom", TriggerCandidateData::Algorithm::kCustom)
+    .value("kChannelDistance", TriggerCandidateData::Algorithm::kChannelDistance)
     .export_values();
 
   py::class_<TriggerCandidateData>(m, "TriggerCandidateData", py::buffer_protocol())


### PR DESCRIPTION
Updates to the Algorithm and Type fields for `TriggerActivityData` and `TriggerCandidateData` to include the new ChannelDistance algorithm.

Changes were made to both Algorithm and Type for the TC case for historical reasons. This is expected to change with the refinement on the meaning of each field.

This is a result from https://github.com/DUNE-DAQ/triggeralgs/pull/60.