### PR TITLE
New DBSCAN TCMaker

### DIFF
--- a/include/trgdataformats/TriggerCandidateData.hpp
+++ b/include/trgdataformats/TriggerCandidateData.hpp
@@ -31,6 +31,7 @@ struct TriggerCandidateData
     kHorizontalMuon = 7,
     kMichelElectron = 8,
     kPlaneCoincidence = 9,
+    kDBSCAN = 10,
   };
 
   enum class Algorithm
@@ -44,6 +45,7 @@ struct TriggerCandidateData
     kMichelElectron = 6, 
     kPlaneCoincidence = 7,    
     kCustom = 8, 
+    kDBSCAN = 9,
   };
 
   // Update this version number if there are any changes to the in-memory representation of this class!
@@ -77,6 +79,7 @@ get_trigger_candidate_type_names()
     { TriggerCandidateData::Type::kHorizontalMuon, "kHorizontalMuon" },
     { TriggerCandidateData::Type::kMichelElectron, "kMichelElectron" },
     { TriggerCandidateData::Type::kPlaneCoincidence, "kPlaneCoincidence" },
+    { TriggerCandidateData::Type::kDBSCAN, "kDBSCAN" },
   };
 }
 

--- a/pybindsrc/trigger_candidate.cpp
+++ b/pybindsrc/trigger_candidate.cpp
@@ -53,6 +53,7 @@ register_trigger_candidate(py::module& m)
     .value("kHorizontalMuon", TriggerCandidateData::Type::kHorizontalMuon)
     .value("kMichelElectron", TriggerCandidateData::Type::kMichelElectron)
     .value("kPlaneCoincidence", TriggerCandidateData::Type::kPlaneCoincidence)
+    .value("kDBSCAN", TriggerCandidateData::Type::kDBSCAN)
     .export_values();
 
   py::enum_<TriggerCandidateData::Algorithm>(m, "TriggerCandidateData::Algorithm")
@@ -63,6 +64,7 @@ register_trigger_candidate(py::module& m)
     .value("kADCSimpleWindow", TriggerCandidateData::Algorithm::kADCSimpleWindow)
     .value("kHorizontalMuon", TriggerCandidateData::Algorithm::kHorizontalMuon)
     .value("kPlaneCoincidence", TriggerCandidateData::Algorithm::kPlaneCoincidence)
+    .value("kDBSCAN", TriggerCandidateData::Algorithm::kDBSCAN)
     .value("kCustom", TriggerCandidateData::Algorithm::kCustom)
     .export_values();
 


### PR DESCRIPTION
The DBSCAN algorithm on https://github.com/DUNE-DAQ/triggeralgs/pull/61 includes a new TCMaker that is necessary to label the TAMakers. This is to keep up with the new TCMaker.