### PR TITLE
New BundleN Algorithm & Type

### DIFF
--- a/include/trgdataformats/TriggerActivityData.hpp
+++ b/include/trgdataformats/TriggerActivityData.hpp
@@ -33,6 +33,7 @@ struct TriggerActivityData
     kMichelElectron = 5,
     kDBSCAN = 6,
     kPlaneCoincidence = 7,
+    kBundle = 8,
   };
 
   // Update this version number if there are any changes to the in-memory representation of this class!

--- a/include/trgdataformats/TriggerCandidateData.hpp
+++ b/include/trgdataformats/TriggerCandidateData.hpp
@@ -79,6 +79,7 @@ get_trigger_candidate_type_names()
     { TriggerCandidateData::Type::kHorizontalMuon, "kHorizontalMuon" },
     { TriggerCandidateData::Type::kMichelElectron, "kMichelElectron" },
     { TriggerCandidateData::Type::kPlaneCoincidence, "kPlaneCoincidence" },
+    { TriggerCandidateData::Type::kBundle, "kBundle" },
   };
 }
 

--- a/include/trgdataformats/TriggerCandidateData.hpp
+++ b/include/trgdataformats/TriggerCandidateData.hpp
@@ -31,6 +31,7 @@ struct TriggerCandidateData
     kHorizontalMuon = 7,
     kMichelElectron = 8,
     kPlaneCoincidence = 9,
+    kBundle = 10,
   };
 
   enum class Algorithm
@@ -44,6 +45,7 @@ struct TriggerCandidateData
     kMichelElectron = 6, 
     kPlaneCoincidence = 7,    
     kCustom = 8, 
+    kBundle = 9,
   };
 
   // Update this version number if there are any changes to the in-memory representation of this class!

--- a/pybindsrc/trigger_activity.cpp
+++ b/pybindsrc/trigger_activity.cpp
@@ -56,6 +56,7 @@ register_trigger_activity(py::module& m)
     .value("kHorizontalMuon", TriggerActivityData::Algorithm::kHorizontalMuon)
     .value("kMichelElectron", TriggerActivityData::Algorithm::kMichelElectron)
     .value("kDBSCAN", TriggerActivityData::Algorithm::kDBSCAN)
+    .value("kBundle", TriggerActivityData::Algorithm::kBundle)
     .export_values();
 
   py::class_<TriggerActivityData>(m, "TriggerActivityData", py::buffer_protocol())

--- a/pybindsrc/trigger_candidate.cpp
+++ b/pybindsrc/trigger_candidate.cpp
@@ -53,6 +53,7 @@ register_trigger_candidate(py::module& m)
     .value("kHorizontalMuon", TriggerCandidateData::Type::kHorizontalMuon)
     .value("kMichelElectron", TriggerCandidateData::Type::kMichelElectron)
     .value("kPlaneCoincidence", TriggerCandidateData::Type::kPlaneCoincidence)
+    .value("kBundle", TriggerCandidateData::Type::kBundle)
     .export_values();
 
   py::enum_<TriggerCandidateData::Algorithm>(m, "TriggerCandidateData::Algorithm")
@@ -64,6 +65,7 @@ register_trigger_candidate(py::module& m)
     .value("kHorizontalMuon", TriggerCandidateData::Algorithm::kHorizontalMuon)
     .value("kPlaneCoincidence", TriggerCandidateData::Algorithm::kPlaneCoincidence)
     .value("kCustom", TriggerCandidateData::Algorithm::kCustom)
+    .value("kBundle", TriggerCandidateData::Algorithm::kBundle)
     .export_values();
 
   py::class_<TriggerCandidateData>(m, "TriggerCandidateData", py::buffer_protocol())


### PR DESCRIPTION
The new BundleN https://github.com/DUNE-DAQ/triggeralgs/pull/62 TA and TC makers in `triggeralgs` need an identity `kBundle` for algorithm (and type for TC). This is to keep up with that.