### PR TITLE
new TrackFinding algorithm

### DIFF
--- a/include/trgdataformats/TriggerActivityData.hpp
+++ b/include/trgdataformats/TriggerActivityData.hpp
@@ -33,7 +33,9 @@ struct TriggerActivityData
     kMichelElectron = 5,
     kDBSCAN = 6,
     kPlaneCoincidence = 7,
-    kTrackFinding = 8,
+    kChannelDistance = 8,
+    kBundle = 9,
+    kTrackFinding = 10,
   };
 
   // Update this version number if there are any changes to the in-memory representation of this class!

--- a/include/trgdataformats/TriggerActivityData.hpp
+++ b/include/trgdataformats/TriggerActivityData.hpp
@@ -33,8 +33,7 @@ struct TriggerActivityData
     kMichelElectron = 5,
     kDBSCAN = 6,
     kPlaneCoincidence = 7,
-    kChannelDistance = 8,
-    kBundle = 9,
+    kTrackFinding = 8,
   };
 
   // Update this version number if there are any changes to the in-memory representation of this class!

--- a/include/trgdataformats/TriggerCandidateData.hpp
+++ b/include/trgdataformats/TriggerCandidateData.hpp
@@ -31,7 +31,10 @@ struct TriggerCandidateData
     kHorizontalMuon = 7,
     kMichelElectron = 8,
     kPlaneCoincidence = 9,
-    kTrackFinding = 10,
+    kDBSCAN = 10,
+    kChannelDistance = 11,
+    kBundle = 12,
+    kTrackFinding = 13,
   };
 
   enum class Algorithm
@@ -44,8 +47,11 @@ struct TriggerCandidateData
     kHorizontalMuon = 5,
     kMichelElectron = 6, 
     kPlaneCoincidence = 7,    
-    kCustom = 8,
-    kTrackFinding = 9,
+    kCustom = 8, 
+    kDBSCAN = 9,
+    kChannelDistance = 10,
+    kBundle = 11,
+    kTrackFinding = 12,
   };
 
   // Update this version number if there are any changes to the in-memory representation of this class!
@@ -79,6 +85,9 @@ get_trigger_candidate_type_names()
     { TriggerCandidateData::Type::kHorizontalMuon, "kHorizontalMuon" },
     { TriggerCandidateData::Type::kMichelElectron, "kMichelElectron" },
     { TriggerCandidateData::Type::kPlaneCoincidence, "kPlaneCoincidence" },
+    { TriggerCandidateData::Type::kBundle, "kBundle" },
+    { TriggerCandidateData::Type::kChannelDistance, "kChannelDistance" },
+    { TriggerCandidateData::Type::kDBSCAN, "kDBSCAN" },
     { TriggerCandidateData::Type::kTrackFinding, "kTrackFinding" },
   };
 }

--- a/include/trgdataformats/TriggerCandidateData.hpp
+++ b/include/trgdataformats/TriggerCandidateData.hpp
@@ -31,9 +31,7 @@ struct TriggerCandidateData
     kHorizontalMuon = 7,
     kMichelElectron = 8,
     kPlaneCoincidence = 9,
-    kDBSCAN = 10,
-    kChannelDistance = 11,
-    kBundle = 12,
+    kTrackFinding = 10,
   };
 
   enum class Algorithm
@@ -46,10 +44,8 @@ struct TriggerCandidateData
     kHorizontalMuon = 5,
     kMichelElectron = 6, 
     kPlaneCoincidence = 7,    
-    kCustom = 8, 
-    kDBSCAN = 9,
-    kChannelDistance = 10,
-    kBundle = 11,
+    kCustom = 8,
+    kTrackFinding = 5,
   };
 
   // Update this version number if there are any changes to the in-memory representation of this class!
@@ -83,9 +79,7 @@ get_trigger_candidate_type_names()
     { TriggerCandidateData::Type::kHorizontalMuon, "kHorizontalMuon" },
     { TriggerCandidateData::Type::kMichelElectron, "kMichelElectron" },
     { TriggerCandidateData::Type::kPlaneCoincidence, "kPlaneCoincidence" },
-    { TriggerCandidateData::Type::kBundle, "kBundle" },
-    { TriggerCandidateData::Type::kChannelDistance, "kChannelDistance" },
-    { TriggerCandidateData::Type::kDBSCAN, "kDBSCAN" },
+    { TriggerCandidateData::Type::kTrackFinding, "kTrackFinding" },
   };
 }
 

--- a/include/trgdataformats/TriggerCandidateData.hpp
+++ b/include/trgdataformats/TriggerCandidateData.hpp
@@ -45,7 +45,7 @@ struct TriggerCandidateData
     kMichelElectron = 6, 
     kPlaneCoincidence = 7,    
     kCustom = 8,
-    kTrackFinding = 5,
+    kTrackFinding = 9,
   };
 
   // Update this version number if there are any changes to the in-memory representation of this class!

--- a/pybindsrc/trigger_activity.cpp
+++ b/pybindsrc/trigger_activity.cpp
@@ -56,6 +56,8 @@ register_trigger_activity(py::module& m)
     .value("kHorizontalMuon", TriggerActivityData::Algorithm::kHorizontalMuon)
     .value("kMichelElectron", TriggerActivityData::Algorithm::kMichelElectron)
     .value("kDBSCAN", TriggerActivityData::Algorithm::kDBSCAN)
+    .value("kBundle", TriggerActivityData::Algorithm::kBundle)
+    .value("kChannelDistance", TriggerActivityData::Algorithm::kChannelDistance)
     .value("kTrackFinding", TriggerActivityData::Algorithm::kTrackFinding)
     .export_values();
 

--- a/pybindsrc/trigger_activity.cpp
+++ b/pybindsrc/trigger_activity.cpp
@@ -56,8 +56,7 @@ register_trigger_activity(py::module& m)
     .value("kHorizontalMuon", TriggerActivityData::Algorithm::kHorizontalMuon)
     .value("kMichelElectron", TriggerActivityData::Algorithm::kMichelElectron)
     .value("kDBSCAN", TriggerActivityData::Algorithm::kDBSCAN)
-    .value("kBundle", TriggerActivityData::Algorithm::kBundle)
-    .value("kChannelDistance", TriggerActivityData::Algorithm::kChannelDistance)
+    .value("kTrackFinding", TriggerActivityData::Algorithm::kTrackFinding)
     .export_values();
 
   py::class_<TriggerActivityData>(m, "TriggerActivityData", py::buffer_protocol())

--- a/pybindsrc/trigger_candidate.cpp
+++ b/pybindsrc/trigger_candidate.cpp
@@ -53,6 +53,9 @@ register_trigger_candidate(py::module& m)
     .value("kHorizontalMuon", TriggerCandidateData::Type::kHorizontalMuon)
     .value("kMichelElectron", TriggerCandidateData::Type::kMichelElectron)
     .value("kPlaneCoincidence", TriggerCandidateData::Type::kPlaneCoincidence)
+    .value("kBundle", TriggerCandidateData::Type::kBundle)
+    .value("kChannelDistance", TriggerCandidateData::Type::kChannelDistance)
+    .value("kDBSCAN", TriggerCandidateData::Type::kDBSCAN)
     .value("kTrackFinding", TriggerCandidateData::Type::kTrackFinding)
     .export_values();
 
@@ -64,7 +67,10 @@ register_trigger_candidate(py::module& m)
     .value("kADCSimpleWindow", TriggerCandidateData::Algorithm::kADCSimpleWindow)
     .value("kHorizontalMuon", TriggerCandidateData::Algorithm::kHorizontalMuon)
     .value("kPlaneCoincidence", TriggerCandidateData::Algorithm::kPlaneCoincidence)
+    .value("kDBSCAN", TriggerCandidateData::Algorithm::kDBSCAN)
     .value("kCustom", TriggerCandidateData::Algorithm::kCustom)
+    .value("kBundle", TriggerCandidateData::Algorithm::kBundle)
+    .value("kChannelDistance", TriggerCandidateData::Algorithm::kChannelDistance)
     .value("kTrackFinding", TriggerCandidateData::Algorithm::kTrackFinding)
     .export_values();
 

--- a/pybindsrc/trigger_candidate.cpp
+++ b/pybindsrc/trigger_candidate.cpp
@@ -53,9 +53,7 @@ register_trigger_candidate(py::module& m)
     .value("kHorizontalMuon", TriggerCandidateData::Type::kHorizontalMuon)
     .value("kMichelElectron", TriggerCandidateData::Type::kMichelElectron)
     .value("kPlaneCoincidence", TriggerCandidateData::Type::kPlaneCoincidence)
-    .value("kBundle", TriggerCandidateData::Type::kBundle)
-    .value("kChannelDistance", TriggerCandidateData::Type::kChannelDistance)
-    .value("kDBSCAN", TriggerCandidateData::Type::kDBSCAN)
+    .value("kTrackFinding", TriggerCandidateData::Type::kTrackFinding)
     .export_values();
 
   py::enum_<TriggerCandidateData::Algorithm>(m, "TriggerCandidateData::Algorithm")
@@ -66,10 +64,8 @@ register_trigger_candidate(py::module& m)
     .value("kADCSimpleWindow", TriggerCandidateData::Algorithm::kADCSimpleWindow)
     .value("kHorizontalMuon", TriggerCandidateData::Algorithm::kHorizontalMuon)
     .value("kPlaneCoincidence", TriggerCandidateData::Algorithm::kPlaneCoincidence)
-    .value("kDBSCAN", TriggerCandidateData::Algorithm::kDBSCAN)
     .value("kCustom", TriggerCandidateData::Algorithm::kCustom)
-    .value("kBundle", TriggerCandidateData::Algorithm::kBundle)
-    .value("kChannelDistance", TriggerCandidateData::Algorithm::kChannelDistance)
+    .value("kTrackFinding", TriggerCandidateData::Algorithm::kTrackFinding)
     .export_values();
 
   py::class_<TriggerCandidateData>(m, "TriggerCandidateData", py::buffer_protocol())


### PR DESCRIPTION
The TrackFinding algorithm is a refined version of the HorizontalMuon algorithm (only the TA maker part for the moment). TA logic changes: in a given TP window (of default 8000 ticks), when TAs are constructed, they only contain the TPs which form an activity/track (and are not the outliers). More than one TAs per window are allowed but they should not be overlapping!

More details can be found here https://indico.fnal.gov/event/63863/ (Horizontal Muon refinement by SS Chhibra)