### PR TITLE
new ChannelAdjacency algorithm

### DIFF
--- a/include/trgdataformats/TriggerActivityData.hpp
+++ b/include/trgdataformats/TriggerActivityData.hpp
@@ -35,6 +35,7 @@ struct TriggerActivityData
     kPlaneCoincidence = 7,
     kChannelDistance = 8,
     kBundle = 9,
+    kChannelAdjacency = 10,
   };
 
   // Update this version number if there are any changes to the in-memory representation of this class!

--- a/include/trgdataformats/TriggerCandidateData.hpp
+++ b/include/trgdataformats/TriggerCandidateData.hpp
@@ -45,6 +45,7 @@ struct TriggerCandidateData
     kCTBCosmicJura = 21,
     kCTBCosmicSaleve = 22,
     kNeutronSourceCalib = 23,
+    kChannelAdjacency = 24,
   };
 
   enum class Algorithm
@@ -61,6 +62,7 @@ struct TriggerCandidateData
     kDBSCAN = 9,
     kChannelDistance = 10,
     kBundle = 11,
+    kChannelAdjacency = 12,
   };
 
   // Update this version number if there are any changes to the in-memory representation of this class!
@@ -108,6 +110,7 @@ get_trigger_candidate_type_names()
     { TriggerCandidateData::Type::kCTBCosmicJura,        "kCTBCosmicJura" },
     { TriggerCandidateData::Type::kCTBCosmicSaleve,      "kCTBCosmicSaleve" },
     { TriggerCandidateData::Type::kNeutronSourceCalib,   "kNeutronSourceCalib" },
+    { TriggerCandidateData::Type::kChannelAdjacency,     "kChannelAdjacency" },
   };
 }
 

--- a/pybindsrc/trigger_activity.cpp
+++ b/pybindsrc/trigger_activity.cpp
@@ -58,6 +58,7 @@ register_trigger_activity(py::module& m)
     .value("kDBSCAN", TriggerActivityData::Algorithm::kDBSCAN)
     .value("kBundle", TriggerActivityData::Algorithm::kBundle)
     .value("kChannelDistance", TriggerActivityData::Algorithm::kChannelDistance)
+    .value("kChannelAdjacency", TriggerActivityData::Algorithm::kChannelAdjacency)
     .export_values();
 
   py::class_<TriggerActivityData>(m, "TriggerActivityData", py::buffer_protocol())

--- a/pybindsrc/trigger_candidate.cpp
+++ b/pybindsrc/trigger_candidate.cpp
@@ -67,6 +67,7 @@ register_trigger_candidate(py::module& m)
     .value("kCTBCosmicJura", TriggerCandidateData::Type::kCTBCosmicJura)
     .value("kCTBCosmicSaleve", TriggerCandidateData::Type::kCTBCosmicSaleve)
     .value("kNeutronSourceCalib", TriggerCandidateData::Type::kNeutronSourceCalib)
+    .value("kChannelAdjacency", TriggerCandidateData::Type::kChannelAdjacency)
     .export_values();
 
   py::enum_<TriggerCandidateData::Algorithm>(m, "TriggerCandidateData::Algorithm")
@@ -81,6 +82,7 @@ register_trigger_candidate(py::module& m)
     .value("kDBSCAN", TriggerCandidateData::Algorithm::kDBSCAN)
     .value("kChannelDistance", TriggerCandidateData::Algorithm::kChannelDistance)
     .value("kBundle", TriggerCandidateData::Algorithm::kBundle)
+    .value("kChannelAdjacency", TriggerCandidateData::Algorithm::kChannelAdjacency)
     .export_values();
 
   py::class_<TriggerCandidateData>(m, "TriggerCandidateData", py::buffer_protocol())


### PR DESCRIPTION
The ChannelAdjacency algorithm is a refined version of the HorizontalMuon algorithm (only the TA maker part for the moment). TA logic changes: in a given TP window (of default 8000 ticks), when TAs are constructed, they only contain the TPs which form an activity/track (and are not the outliers). More than one TAs per window are allowed but they should not be overlapping!

More details can be found here https://indico.fnal.gov/event/63863/ (Horizontal Muon refinement by SS Chhibra)
