### PR TITLE
Corrected PyBind Enum Names

### DIFF
--- a/pybindsrc/trigger_activity.cpp
+++ b/pybindsrc/trigger_activity.cpp
@@ -42,26 +42,8 @@ register_trigger_activity(py::module& m)
 {
 
 
-  py::enum_<TriggerActivityData::Type>(m, "TriggerActivityData::Type")
-    .value("kUnknown", TriggerActivityData::Type::kUnknown)
-    .value("kTPC", TriggerActivityData::Type::kTPC)
-    .value("kPDS", TriggerActivityData::Type::kPDS)
-    .export_values();
-
-  py::enum_<TriggerActivityData::Algorithm>(m, "TriggerActivityData::Algorithm")
-    .value("kUnknown", TriggerActivityData::Algorithm::kUnknown)
-    .value("kSupernova", TriggerActivityData::Algorithm::kSupernova)
-    .value("kPrescale", TriggerActivityData::Algorithm::kPrescale)
-    .value("kADCSimpleWindow", TriggerActivityData::Algorithm::kADCSimpleWindow)
-    .value("kHorizontalMuon", TriggerActivityData::Algorithm::kHorizontalMuon)
-    .value("kMichelElectron", TriggerActivityData::Algorithm::kMichelElectron)
-    .value("kDBSCAN", TriggerActivityData::Algorithm::kDBSCAN)
-    .value("kBundle", TriggerActivityData::Algorithm::kBundle)
-    .value("kChannelDistance", TriggerActivityData::Algorithm::kChannelDistance)
-    .value("kChannelAdjacency", TriggerActivityData::Algorithm::kChannelAdjacency)
-    .export_values();
-
-  py::class_<TriggerActivityData>(m, "TriggerActivityData", py::buffer_protocol())
+  py::class_<TriggerActivityData> trigger_activity_data(m, "TriggerActivityData", py::buffer_protocol());
+  trigger_activity_data
     .def(py::init())
     .def(py::init([](py::capsule capsule) {
         auto tp = *static_cast<TriggerActivityData*>(capsule.get_pointer());
@@ -88,6 +70,23 @@ register_trigger_activity(py::module& m)
     .def_static("sizeof", [](){ return sizeof(TriggerActivityData); })
     ;
 
+
+  py::enum_<TriggerActivityData::Type>(trigger_activity_data, "Type")
+    .value("kUnknown", TriggerActivityData::Type::kUnknown)
+    .value("kTPC", TriggerActivityData::Type::kTPC)
+    .value("kPDS", TriggerActivityData::Type::kPDS);
+
+  py::enum_<TriggerActivityData::Algorithm>(trigger_activity_data, "Algorithm")
+    .value("kUnknown", TriggerActivityData::Algorithm::kUnknown)
+    .value("kSupernova", TriggerActivityData::Algorithm::kSupernova)
+    .value("kPrescale", TriggerActivityData::Algorithm::kPrescale)
+    .value("kADCSimpleWindow", TriggerActivityData::Algorithm::kADCSimpleWindow)
+    .value("kHorizontalMuon", TriggerActivityData::Algorithm::kHorizontalMuon)
+    .value("kMichelElectron", TriggerActivityData::Algorithm::kMichelElectron)
+    .value("kDBSCAN", TriggerActivityData::Algorithm::kDBSCAN)
+    .value("kBundle", TriggerActivityData::Algorithm::kBundle)
+    .value("kChannelDistance", TriggerActivityData::Algorithm::kChannelDistance)
+    .value("kChannelAdjacency", TriggerActivityData::Algorithm::kChannelAdjacency);
 
   py::class_<TriggerActivity>(m, "TriggerActivityOverlay", py::buffer_protocol())
       .def(py::init())

--- a/pybindsrc/trigger_candidate.cpp
+++ b/pybindsrc/trigger_candidate.cpp
@@ -43,7 +43,29 @@ register_trigger_candidate(py::module& m)
 
   m.def("string_to_fragment_type_value", &trgdataformats::string_to_fragment_type_value);
 
-  py::enum_<TriggerCandidateData::Type>(m, "TriggerCandidateData::Type")
+  py::class_<TriggerCandidateData> trigger_candidate_data(m, "TriggerCandidateData", py::buffer_protocol());
+  trigger_candidate_data
+    .def(py::init())
+    .def(py::init([](py::capsule capsule) {
+        auto tp = *static_cast<TriggerCandidateData*>(capsule.get_pointer());
+        return tp;
+		  } ))
+    .def(py::init([](py::bytes bytes){
+      py::buffer_info info(py::buffer(bytes).request());
+      auto tp = *static_cast<TriggerCandidateData*>(info.ptr);
+      return tp;
+    }))
+    .def_property_readonly("version", [](TriggerCandidateData& self) -> uint16_t {return self.version;})
+    .def_property_readonly("time_start", [](TriggerCandidateData& self) -> uint64_t {return self.time_start;})
+    .def_property_readonly("time_end", [](TriggerCandidateData& self) -> uint64_t {return self.time_end;})
+    .def_property_readonly("time_candidate", [](TriggerCandidateData& self) -> uint64_t {return self.time_candidate;})
+    .def_property_readonly("detid", [](TriggerCandidateData& self) -> uint16_t {return self.detid;})
+    .def_property_readonly("type", [](TriggerCandidateData& self) -> TriggerCandidateData::Type {return self.type;})
+    .def_property_readonly("algorithm", [](TriggerCandidateData& self) -> TriggerCandidateData::Algorithm {return self.algorithm;})
+    .def_static("sizeof", [](){ return sizeof(TriggerCandidateData); })
+    ;
+
+  py::enum_<TriggerCandidateData::Type>(trigger_candidate_data, "Type")
     .value("kUnknown", TriggerCandidateData::Type::kUnknown)
     .value("kTiming", TriggerCandidateData::Type::kTiming)
     .value("kTPCLowE", TriggerCandidateData::Type::kTPCLowE)
@@ -71,10 +93,9 @@ register_trigger_candidate(py::module& m)
     .value("kCIBFakeTrigger", TriggerCandidateData::Type::kCIBFakeTrigger)
     .value("kCIBLaserTriggerP1", TriggerCandidateData::Type::kCIBLaserTriggerP1)
     .value("kCIBLaserTriggerP2", TriggerCandidateData::Type::kCIBLaserTriggerP2)
-    .value("kCIBLaserTriggerP3", TriggerCandidateData::Type::kCIBLaserTriggerP3)
-    .export_values();
+    .value("kCIBLaserTriggerP3", TriggerCandidateData::Type::kCIBLaserTriggerP3);
 
-  py::enum_<TriggerCandidateData::Algorithm>(m, "TriggerCandidateData::Algorithm")
+  py::enum_<TriggerCandidateData::Algorithm>(trigger_candidate_data, "Algorithm")
     .value("kUnknown", TriggerCandidateData::Algorithm::kUnknown)
     .value("kSupernova", TriggerCandidateData::Algorithm::kSupernova)
     .value("kHSIEventToTriggerCandidate", TriggerCandidateData::Algorithm::kHSIEventToTriggerCandidate)
@@ -86,30 +107,7 @@ register_trigger_candidate(py::module& m)
     .value("kDBSCAN", TriggerCandidateData::Algorithm::kDBSCAN)
     .value("kChannelDistance", TriggerCandidateData::Algorithm::kChannelDistance)
     .value("kBundle", TriggerCandidateData::Algorithm::kBundle)
-    .value("kChannelAdjacency", TriggerCandidateData::Algorithm::kChannelAdjacency)
-    .export_values();
-
-  py::class_<TriggerCandidateData>(m, "TriggerCandidateData", py::buffer_protocol())
-    .def(py::init())
-    .def(py::init([](py::capsule capsule) {
-        auto tp = *static_cast<TriggerCandidateData*>(capsule.get_pointer());
-        return tp;
-		  } ))
-    .def(py::init([](py::bytes bytes){
-      py::buffer_info info(py::buffer(bytes).request());
-      auto tp = *static_cast<TriggerCandidateData*>(info.ptr);
-      return tp;
-    }))
-    .def_property_readonly("version", [](TriggerCandidateData& self) -> uint16_t {return self.version;})
-    .def_property_readonly("time_start", [](TriggerCandidateData& self) -> uint64_t {return self.time_start;})
-    .def_property_readonly("time_end", [](TriggerCandidateData& self) -> uint64_t {return self.time_end;})
-    .def_property_readonly("time_candidate", [](TriggerCandidateData& self) -> uint64_t {return self.time_candidate;})
-    .def_property_readonly("detid", [](TriggerCandidateData& self) -> uint16_t {return self.detid;})
-    .def_property_readonly("type", [](TriggerCandidateData& self) -> TriggerCandidateData::Type {return self.type;})
-    .def_property_readonly("algorithm", [](TriggerCandidateData& self) -> TriggerCandidateData::Algorithm {return self.algorithm;})
-    .def_static("sizeof", [](){ return sizeof(TriggerCandidateData); })
-    ;
-
+    .value("kChannelAdjacency", TriggerCandidateData::Algorithm::kChannelAdjacency);
 
   py::class_<TriggerCandidate>(m, "TriggerCandidateOverlay", py::buffer_protocol())
       .def(py::init())

--- a/pybindsrc/trigger_primitive.cpp
+++ b/pybindsrc/trigger_primitive.cpp
@@ -20,20 +20,8 @@ register_trigger_primitive(py::module& m)
 {
 
 
-  py::enum_<TriggerPrimitive::Type>(m, "TriggerPrimitive::Type")
-    .value("kUnknown", TriggerPrimitive::Type::kUnknown)
-    .value("kTPC", TriggerPrimitive::Type::kTPC)
-    .value("kPDS", TriggerPrimitive::Type::kPDS)
-    .export_values();
-
-  py::enum_<TriggerPrimitive::Algorithm>(m, "TriggerPrimitive::Algorithm")
-    .value("kUnknown", TriggerPrimitive::Algorithm::kUnknown)
-    .value("kSimpleThreshold", TriggerPrimitive::Algorithm::kSimpleThreshold)
-    .value("kAbsRunningSum", TriggerPrimitive::Algorithm::kAbsRunningSum)
-    .value("kRunningSum", TriggerPrimitive::Algorithm::kRunningSum)
-    .export_values();
-
-  py::class_<TriggerPrimitive>(m, "TriggerPrimitive", py::buffer_protocol())
+  py::class_<TriggerPrimitive> trigger_primitive(m, "TriggerPrimitive", py::buffer_protocol());
+  trigger_primitive
     .def(py::init())
     .def(py::init([](py::capsule capsule) {
         auto tp = *static_cast<TriggerPrimitive*>(capsule.get_pointer());
@@ -52,6 +40,17 @@ register_trigger_primitive(py::module& m)
     .def_property_readonly("flag", [](TriggerPrimitive& self) -> uint16_t {return self.flag;})
     .def_static("sizeof", [](){ return sizeof(TriggerPrimitive); })
     ;
+
+  py::enum_<TriggerPrimitive::Type>(trigger_primitive, "Type")
+    .value("kUnknown", TriggerPrimitive::Type::kUnknown)
+    .value("kTPC", TriggerPrimitive::Type::kTPC)
+    .value("kPDS", TriggerPrimitive::Type::kPDS);
+
+  py::enum_<TriggerPrimitive::Algorithm>(trigger_primitive, "Algorithm")
+    .value("kUnknown", TriggerPrimitive::Algorithm::kUnknown)
+    .value("kSimpleThreshold", TriggerPrimitive::Algorithm::kSimpleThreshold)
+    .value("kAbsRunningSum", TriggerPrimitive::Algorithm::kAbsRunningSum)
+    .value("kRunningSum", TriggerPrimitive::Algorithm::kRunningSum);
 
 }
 


### PR DESCRIPTION
This closes issue #11. Accessing the enums in python was tested as follows:
```python
import trgdataformats
print(trgdataformats.TriggerActivityData.Algorithm.kPrescale.name)   # kPrescale
print(trgdataformats.TriggerActivityData.Algorithm.kPrescale.value)  # 2
print(trgdataformats.TriggerActivityData.Type.kTPC.name)   # kTPC
print(trgdataformats.TriggerActivityData.Type.kTPC.value)  # 1
```

This was repeated for `trgdataformats.TriggerPrimitive` and `trgdataformats.TriggerCandidateData` and various other types and algorithms. I also tested the functionality in `trgtools` and found that everything continued to work as expected.