### PR TITLE
Channel-time adjacency algorithm implementation

### DIFF
--- a/include/trgdataformats/TriggerActivityData.hpp
+++ b/include/trgdataformats/TriggerActivityData.hpp
@@ -36,6 +36,7 @@ struct TriggerActivityData
     kChannelDistance = 8,
     kBundle = 9,
     kChannelAdjacency = 10,
+    kChannelTimeAdjacency = 11,
   };
 
   // Update this version number if there are any changes to the in-memory representation of this class!

--- a/include/trgdataformats/TriggerCandidateData.hpp
+++ b/include/trgdataformats/TriggerCandidateData.hpp
@@ -50,6 +50,7 @@ struct TriggerCandidateData
     kCIBLaserTriggerP1 = 26,
     kCIBLaserTriggerP2 = 27,
     kCIBLaserTriggerP3 = 28,
+    kChannelTimeAdjacency = 29,
   };
 
   enum class Algorithm
@@ -67,6 +68,7 @@ struct TriggerCandidateData
     kChannelDistance = 10,
     kBundle = 11,
     kChannelAdjacency = 12,
+    kChannelTimeAdjacency = 13,
   };
 
   // Update this version number if there are any changes to the in-memory representation of this class!
@@ -119,6 +121,7 @@ get_trigger_candidate_type_names()
     { TriggerCandidateData::Type::kCIBLaserTriggerP1,    "kCIBLaserTriggerP1" },
     { TriggerCandidateData::Type::kCIBLaserTriggerP2,    "kCIBLaserTriggerP2" },
     { TriggerCandidateData::Type::kCIBLaserTriggerP3,    "kCIBLaserTriggerP3" },
+    { TriggerCandidateData::Type::kChannelTimeAdjacency, "kChannelTimeAdjacency" },
   };
 }
 

--- a/pybindsrc/trigger_activity.cpp
+++ b/pybindsrc/trigger_activity.cpp
@@ -86,7 +86,8 @@ register_trigger_activity(py::module& m)
     .value("kDBSCAN", TriggerActivityData::Algorithm::kDBSCAN)
     .value("kBundle", TriggerActivityData::Algorithm::kBundle)
     .value("kChannelDistance", TriggerActivityData::Algorithm::kChannelDistance)
-    .value("kChannelAdjacency", TriggerActivityData::Algorithm::kChannelAdjacency);
+    .value("kChannelAdjacency", TriggerActivityData::Algorithm::kChannelAdjacency)
+    .value("kChannelTimeAdjacency", TriggerActivityData::Algorithm::kChannelTimeAdjacency);
 
   py::class_<TriggerActivity>(m, "TriggerActivityOverlay", py::buffer_protocol())
       .def(py::init())

--- a/pybindsrc/trigger_candidate.cpp
+++ b/pybindsrc/trigger_candidate.cpp
@@ -93,7 +93,8 @@ register_trigger_candidate(py::module& m)
     .value("kCIBFakeTrigger", TriggerCandidateData::Type::kCIBFakeTrigger)
     .value("kCIBLaserTriggerP1", TriggerCandidateData::Type::kCIBLaserTriggerP1)
     .value("kCIBLaserTriggerP2", TriggerCandidateData::Type::kCIBLaserTriggerP2)
-    .value("kCIBLaserTriggerP3", TriggerCandidateData::Type::kCIBLaserTriggerP3);
+    .value("kCIBLaserTriggerP3", TriggerCandidateData::Type::kCIBLaserTriggerP3)
+    .value("kChannelTimeAdjacency", TriggerCandidateData::Type::kChannelTimeAdjacency);
 
   py::enum_<TriggerCandidateData::Algorithm>(trigger_candidate_data, "Algorithm")
     .value("kUnknown", TriggerCandidateData::Algorithm::kUnknown)
@@ -107,7 +108,8 @@ register_trigger_candidate(py::module& m)
     .value("kDBSCAN", TriggerCandidateData::Algorithm::kDBSCAN)
     .value("kChannelDistance", TriggerCandidateData::Algorithm::kChannelDistance)
     .value("kBundle", TriggerCandidateData::Algorithm::kBundle)
-    .value("kChannelAdjacency", TriggerCandidateData::Algorithm::kChannelAdjacency);
+    .value("kChannelAdjacency", TriggerCandidateData::Algorithm::kChannelAdjacency)
+    .value("kChannelTimeAdjacency", TriggerCandidateData::Algorithm::kChannelTimeAdjacency);
 
   py::class_<TriggerCandidate>(m, "TriggerCandidateOverlay", py::buffer_protocol())
       .def(py::init([](py::capsule capsule) {


### PR DESCRIPTION

# ChannelTimeAdjacency Algorithm

The ChannelTimeAdjacency algorithm is an enhanced version of the adjacency algorithm implemented for the HorizontalMuon algorithm, specifically focusing on the TA maker part.

## Overview

The algorithm constructs Trigger Activities (TAs) by analyzing Trigger Primitives (TPs) within a given time window. TAs are formed by grouping TPs that represent an activity or track, excluding background/outliers. The longest track is stored in the time window.

## Key Features

- Improved version of the adjacency logic present at the HorizontalMuon algorithm.
- Constructs TAs based on TPs within a TP window that have a channel-time correlation.
- Excludes background/outliers from TAs.

## References

- [Adjacency trigger refinement by Hamza Amar Es-sghir (IFIC-Valencia, Spain)](https://indico.fnal.gov/event/64229/)