### PR TITLE
Add PlaneCoincidence PyBind

### DIFF
--- a/pybindsrc/trigger_activity.cpp
+++ b/pybindsrc/trigger_activity.cpp
@@ -84,6 +84,7 @@ register_trigger_activity(py::module& m)
     .value("kHorizontalMuon", TriggerActivityData::Algorithm::kHorizontalMuon)
     .value("kMichelElectron", TriggerActivityData::Algorithm::kMichelElectron)
     .value("kDBSCAN", TriggerActivityData::Algorithm::kDBSCAN)
+    .value("kPlaneCoincidence", TriggerActivityData::Algorithm::kPlaneCoincidence)
     .value("kBundle", TriggerActivityData::Algorithm::kBundle)
     .value("kChannelDistance", TriggerActivityData::Algorithm::kChannelDistance)
     .value("kChannelAdjacency", TriggerActivityData::Algorithm::kChannelAdjacency);


### PR DESCRIPTION
Added the missing `kPlaneCoincidence` python binding for TriggerActivity algorithms. Closes #43.

Testing was done as
```python
import trgdataformats
print(trgdataformats.TriggerActivityData.Algorithm(7))
```
before and after this change.

On the before case, it should print `Algorithm.???`. On the after, `Algorithm.kPlaneCoincidence`.