### PR TITLE
Added a function to translate trigger candidate type to string

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,8 @@ daq_add_python_bindings(*.cpp LINK_LIBRARIES ${PROJECT_NAME} )
 
 ##############################################################################
 
-daq_add_unit_test(Trgdataformats_test LINK_LIBRARIES) 
+daq_add_unit_test(Trgdataformats_test LINK_LIBRARIES)
+daq_add_unit_test(TriggerCandidateData_test LINK_LIBRARIES)
 
 ##############################################################################
 

--- a/include/trgdataformats/TriggerCandidateData.hpp
+++ b/include/trgdataformats/TriggerCandidateData.hpp
@@ -153,6 +153,17 @@ string_to_trigger_candidate_type(const std::string& name)
   return static_cast<int>(TriggerCandidateData::Type::kUnknown);
 }
 
+inline std::string
+trigger_candidate_type_to_string(const TriggerCandidateData::Type& type)
+{
+  try {
+    return get_trigger_candidate_type_names().at(type);
+  }
+  catch(std::exception &e) {
+  }
+  return "kUnknown";
+}
+
 } // namespace dunedaq::trgdataformats
 
 #endif // TRGDATAFORMATS_INCLUDE_TRGDATAFORMATS_TRIGGERCANDIDATEDATA_HPP_

--- a/pybindsrc/trigger_candidate.cpp
+++ b/pybindsrc/trigger_candidate.cpp
@@ -42,6 +42,7 @@ register_trigger_candidate(py::module& m)
 {
 
   m.def("string_to_trigger_candidate_type", &trgdataformats::string_to_trigger_candidate_type);
+  m.def("trigger_candidate_type_to_string", &trgdataformats::trigger_candidate_type_to_string);
 
   py::class_<TriggerCandidateData> trigger_candidate_data(m, "TriggerCandidateData", py::buffer_protocol());
   trigger_candidate_data

--- a/unittest/TriggerCandidateData_test.cxx
+++ b/unittest/TriggerCandidateData_test.cxx
@@ -1,0 +1,48 @@
+/**
+ * @file TriggerCandidateData_test.cxx TriggerCandidateData class Unit Tests
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "trgdataformats/TriggerCandidateData.hpp"
+
+/**
+ * @brief Name of this test module
+ */
+#define BOOST_TEST_MODULE TriggerCandidateData_test // NOLINT
+
+#include "boost/test/unit_test.hpp"
+
+#include <string>
+#include <vector>
+
+using namespace dunedaq::trgdataformats;
+
+BOOST_AUTO_TEST_SUITE(TriggerCandidateData_test)
+
+BOOST_AUTO_TEST_CASE(FragmentTypeConversion)
+{
+  BOOST_REQUIRE_EQUAL(static_cast<int>(string_to_trigger_candidate_type("kTiming")),
+                      static_cast<int>(TriggerCandidateData::Type::kTiming));
+  BOOST_REQUIRE_EQUAL(trigger_candidate_type_to_string(TriggerCandidateData::Type::kTiming), "kTiming");
+
+  auto type_map = get_trigger_candidate_type_names();
+  // sanity check
+  for (auto& type_pair : type_map) {
+    BOOST_TEST_MESSAGE("TriggerCandidateData type "
+                       << int(type_pair.first) << " " << type_pair.second
+                       << " with conversions: " << int(string_to_trigger_candidate_type(type_pair.second)) << " "
+                       << trigger_candidate_type_to_string(type_pair.first));
+    BOOST_REQUIRE_EQUAL(static_cast<int>(string_to_trigger_candidate_type(type_pair.second)),
+                        static_cast<int>(type_pair.first));
+    BOOST_REQUIRE_EQUAL(trigger_candidate_type_to_string(type_pair.first), type_pair.second);
+  }
+
+  BOOST_REQUIRE_EQUAL(static_cast<int>(string_to_trigger_candidate_type("thisIsABadFragmentType")),
+                      static_cast<int>(TriggerCandidateData::Type::kUnknown));
+  BOOST_REQUIRE_EQUAL(trigger_candidate_type_to_string(static_cast<TriggerCandidateData::Type>(-10)), "kUnknown");
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Also, added a `TriggerCandidateData` unit test to validate the translations to/from TC types and strings.

This change was made as part of providing the ability to apply different acceptance criteria for different trigger types in automated integration tests (i.e. the `integrationtest` package `data_file_checks`).

The simplest way to test these changes is to run the new unit test...

- create a software area based on a recent nightly build
- add this repo to that software area and check out the kbiery/get_tc_type_names branch; rebuild the software
- `dbt-build --unittest trgdataformats`
- `dbt-unittest-summary.sh`
