### PR TITLE
Added a method to TriggerPrimitive to return the current version number…

### DIFF
--- a/include/trgdataformats/TriggerPrimitive.hpp
+++ b/include/trgdataformats/TriggerPrimitive.hpp
@@ -41,6 +41,8 @@ struct TriggerPrimitive
 
   uint64_t adc_integral : 32 = std::numeric_limits<uint32_t>::max();
   uint64_t adc_peak : 16 = std::numeric_limits<uint16_t>::max();
+
+  uint8_t get_current_version() {return s_trigger_primitive_version;}
 };
 
 } // namespace dunedaq::trgdataformats

--- a/pybindsrc/trigger_primitive.cpp
+++ b/pybindsrc/trigger_primitive.cpp
@@ -37,6 +37,7 @@ register_trigger_primitive(py::module& m)
     .def_property_readonly("detid", [](TriggerPrimitive& self) -> uint8_t {return self.detid;})
     .def_property_readonly("flag", [](TriggerPrimitive& self) -> uint8_t {return self.flag;})
     .def_static("sizeof", [](){ return sizeof(TriggerPrimitive); })
+    .def("get_current_version", &TriggerPrimitive::get_current_version)
     ;
 
 }


### PR DESCRIPTION
…so that it is accessible in python.

This is part of adding TP-data-structure version checking to various data-inspection utilities such as the `tpdecoder.py` script in the `rawdatautils` package.  

I tried to add python bindings directly to the `TriggerPrimitive::s_trigger_primitive_version` static data member, but I couldn't get that to work, so I went with this solution.  If someone is able to get that to work, I will gladly change the python code that needs access to `s_trigger_primitive_version`.

Note that the changes in this PR, on the `kbiery/tp_get_current_version` branch, are based on the current state of the `aeo/new_tp_format` branch.